### PR TITLE
include babel-runtime in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "babel-relay-plugin": "^0.6.1",
+    "babel-runtime": "^6.9.2",
     "browser-sync-webpack-plugin": "^1.0.1",
     "chai": "^3.2.0",
     "css-loader": "^0.19.0",


### PR DESCRIPTION
There was a babel-runtime error when trying to `npm run startdev` so i included babel-runtime as a devDependency to fix the error. Now, a simple `npm install && npm run startdev` will run without errors.
